### PR TITLE
Update assembly version code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ Third Party/MetroFramework/MetroFramework/obj
 /packages
 /Authenticator/obj
 /Authenticator/bin
+.vs
+x64

--- a/WinAuth/Properties/AssemblyInfo.cs
+++ b/WinAuth/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.6.5.3")]
-[assembly: AssemblyFileVersion("3.6.5.3")]
+[assembly: AssemblyVersion("3.6.6.3")]
+[assembly: AssemblyFileVersion("3.6.6.3")]
 [assembly: NeutralResourcesLanguageAttribute("")]


### PR DESCRIPTION
This makes it *much* easier to tell what version I'm running (especially given that warning when you start up this release). If you're like me and have multiple versions of WinAuth hanging around, you can see which is which in file properties -> details.


Also, I recommend removing the suggestion for an *unencrypted* backup; instead, you just want a *backup*, but you probably want it as an encrypted zip or gpg (windows explorer and 7zip can both deal with this encrypted zip file).